### PR TITLE
Added cgal wrappers. From CGAL to deal.II tria.

### DIFF
--- a/gtests/boolean_difference.cc
+++ b/gtests/boolean_difference.cc
@@ -22,6 +22,7 @@
 #  include <deal.II/grid/grid_generator.h>
 #  include <deal.II/grid/tria.h>
 
+#  include "cgal/wrappers.h"
 
 // CGAL headers and typedefs
 #  include <CGAL/Boolean_set_operations_2.h>
@@ -128,6 +129,7 @@ mark_domains(CDT &cdt)
 
 
 using namespace dealii;
+using namespace CGALWrappers;
 
 TEST(CGAL, BooleanOperationsPolygons)
 {
@@ -151,10 +153,10 @@ TEST(CGAL, BooleanOperationsPolygons)
   // Create first polygon
 
   std::vector<CGAL_Point> pts0;
-  pts0.emplace_back(cell0->vertex(0)[0], cell0->vertex(0)[1]); // 0
-  pts0.emplace_back(cell0->vertex(1)[0], cell0->vertex(1)[1]); // 1
-  pts0.emplace_back(cell0->vertex(3)[0], cell0->vertex(3)[1]); // 3
-  pts0.emplace_back(cell0->vertex(2)[0], cell0->vertex(2)[1]); // 2
+  pts0.emplace_back(to_cgal<CGAL_Point>(cell0->vertex(0))); // 0
+  pts0.emplace_back(to_cgal<CGAL_Point>(cell0->vertex(1))); // 1
+  pts0.emplace_back(to_cgal<CGAL_Point>(cell0->vertex(3))); // 3
+  pts0.emplace_back(to_cgal<CGAL_Point>(cell0->vertex(2))); // 2
 
   const CGAL_Polygon p1(pts0.begin(), pts0.end()); // create first Polygon
 
@@ -167,14 +169,12 @@ TEST(CGAL, BooleanOperationsPolygons)
   const auto &cell1 = dh1.begin_active();
 
   std::vector<CGAL_Point> pts1;
-  pts1.emplace_back(cell1->vertex(0)[0], cell1->vertex(0)[1]); // 0
-  pts1.emplace_back(cell1->vertex(1)[0], cell1->vertex(1)[1]); // 1
-  pts1.emplace_back(cell1->vertex(3)[0], cell1->vertex(3)[1]); // 3
-  pts1.emplace_back(cell1->vertex(2)[0], cell1->vertex(2)[1]); // 2
+  pts1.emplace_back(to_cgal<CGAL_Point>(cell1->vertex(0))); // 0
+  pts1.emplace_back(to_cgal<CGAL_Point>(cell1->vertex(1))); // 1
+  pts1.emplace_back(to_cgal<CGAL_Point>(cell1->vertex(3))); // 3
+  pts1.emplace_back(to_cgal<CGAL_Point>(cell1->vertex(2))); // 2
 
   const CGAL_Polygon p2(pts1.begin(), pts1.end()); // second Polygon
-
-
 
   std::vector<Polygon_with_holes_2> poly_list;
   [[maybe_unused]] auto             outp_iter =
@@ -202,7 +202,6 @@ TEST(CGAL, BooleanOperationsPolygons)
 
   mark_domains(cdt);
 
-
   std::array<Point<dim0>, 3> vertices;
   double                     sum = 0.;
   // Loop over finite faces (or "cells" in dealii), get the area of that element
@@ -213,9 +212,7 @@ TEST(CGAL, BooleanOperationsPolygons)
         {
           for (unsigned int i = 0; i < 3; ++i)
             {
-              vertices[i] =
-                Point<dim0>{CGAL::to_double(cdt.triangle(f).vertex(i).x()),
-                            CGAL::to_double(cdt.triangle(f).vertex(i).y())};
+              vertices[i] = to_dealii<dim0>(cdt.triangle(f).vertex(i));
             }
 
 

--- a/gtests/cgal_triangulation.cc
+++ b/gtests/cgal_triangulation.cc
@@ -1,0 +1,69 @@
+#include <deal.II/base/config.h>
+
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria.h>
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+
+#include "dim_spacedim_tester.h"
+
+using namespace dealii;
+
+// #ifdef DEAL_II_WIHT_CGAL
+
+#include <CGAL/Delaunay_triangulation_2.h>
+#include <CGAL/Regular_triangulation_2.h>
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/point_generators_2.h>
+
+#include "cgal/wrappers.h"
+
+// typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Simple_cartesian<double>    K;
+typedef CGAL::Delaunay_triangulation_2<K> Delaunay;
+typedef Delaunay::Point                   DPoint;
+
+TEST(CGAL, Delaunay2D)
+{
+  CGAL::Random_points_in_disc_2<DPoint> rnd;
+  const unsigned int                    n_vertices = 60;
+
+  std::vector<DPoint> points(n_vertices);
+
+  for (unsigned int i = 0; i < n_vertices; ++i)
+    points[i] = *rnd++;
+  Delaunay cgal_tria(points.begin(), points.end());
+
+
+  std::vector<dealii::Point<2>> vertices;
+  std::vector<CellData<2>>      cells;
+  SubCellData                   subcells;
+
+  std::map<Delaunay::Vertex_handle, unsigned int> v_map;
+  {
+    unsigned int counter = 0;
+    for (const auto &v : cgal_tria.finite_vertex_handles())
+      {
+        v_map[v] = counter++;
+        vertices.emplace_back(CGALWrappers::to_dealii<2>(v->point()));
+      }
+  }
+  for (const auto &cell : cgal_tria.finite_face_handles())
+    {
+      CellData<2> c(3);
+      c.vertices[0] = v_map.at(cell->vertex(0));
+      c.vertices[1] = v_map.at(cell->vertex(1));
+      c.vertices[2] = v_map.at(cell->vertex(2));
+      cells.emplace_back(c);
+    }
+
+  Triangulation<2> tria;
+  tria.create_triangulation(vertices, cells, subcells);
+  ASSERT_EQ(tria.n_active_cells(), cgal_tria.number_of_faces());
+  ASSERT_EQ(tria.n_vertices(), cgal_tria.number_of_vertices());
+}
+
+// #endif

--- a/gtests/compute_intersection_of_cells.cc
+++ b/gtests/compute_intersection_of_cells.cc
@@ -37,10 +37,10 @@
 #  include <CGAL/Triangulation_2.h>
 #  include <gtest/gtest.h>
 
+#  include "cgal/wrappers.h"
 #  include "compute_intersections.h"
 #  include "compute_linear_transformation.h"
 #  include "dim_spacedim_tester.h"
-
 
 
 // CGAL typedefs
@@ -63,6 +63,7 @@ typedef CGAL::Delaunay_mesh_size_criteria_2<CDT>                    Criteria;
 typedef CDT::Vertex_handle Vertex_handle;
 
 using namespace dealii;
+using namespace CGALWrappers;
 
 struct Test_function
 {
@@ -147,10 +148,10 @@ TEST(CGAL, AreaTestCodimension0)
   // Create first polygon
 
   std::vector<CGAL_Point> pts0;
-  pts0.emplace_back(cell0->vertex(0)[0], cell0->vertex(0)[1]); // 0
-  pts0.emplace_back(cell0->vertex(1)[0], cell0->vertex(1)[1]); // 1
-  pts0.emplace_back(cell0->vertex(3)[0], cell0->vertex(3)[1]); // 3
-  pts0.emplace_back(cell0->vertex(2)[0], cell0->vertex(2)[1]); // 2
+  pts0.emplace_back(to_cgal<CGAL_Point>(cell0->vertex(0))); // 0
+  pts0.emplace_back(to_cgal<CGAL_Point>(cell0->vertex(1))); // 1
+  pts0.emplace_back(to_cgal<CGAL_Point>(cell0->vertex(3))); // 3
+  pts0.emplace_back(to_cgal<CGAL_Point>(cell0->vertex(2))); // 2
 
   const CGAL_Polygon p1(pts0.begin(), pts0.end()); // create first Polygon
 
@@ -163,10 +164,10 @@ TEST(CGAL, AreaTestCodimension0)
   const auto &cell1 = dh1.begin_active();
 
   std::vector<CGAL_Point> pts1;
-  pts1.emplace_back(cell1->vertex(0)[0], cell1->vertex(0)[1]); // 0
-  pts1.emplace_back(cell1->vertex(1)[0], cell1->vertex(1)[1]); // 1
-  pts1.emplace_back(cell1->vertex(3)[0], cell1->vertex(3)[1]); // 3
-  pts1.emplace_back(cell1->vertex(2)[0], cell1->vertex(2)[1]); // 2
+  pts1.emplace_back(to_cgal<CGAL_Point>(cell1->vertex(0))); // 0
+  pts1.emplace_back(to_cgal<CGAL_Point>(cell1->vertex(1))); // 1
+  pts1.emplace_back(to_cgal<CGAL_Point>(cell1->vertex(3))); // 3
+  pts1.emplace_back(to_cgal<CGAL_Point>(cell1->vertex(2))); // 2
 
   const CGAL_Polygon p2(pts1.begin(), pts1.end()); // second Polygon
 
@@ -194,20 +195,12 @@ TEST(CGAL, AreaTestCodimension0)
 
   std::array<Point<dim0>, 3> vertices;
   for (unsigned int i = 0; i < 3; ++i)
-    {
-      vertices[i] =
-        Point<dim0>{CGAL::to_double(cdt.triangle(it).vertex(i).x()),
-                    CGAL::to_double(cdt.triangle(it).vertex(i).y())};
-    }
-
-
+    vertices[i] = to_dealii<dim0>(cdt.triangle(it).vertex(i));
 
   // Now construct real quadrature formula over there
   const auto quad_rule_over_triangle =
     compute_linear_transformation<dim0, dim1, 3>(QGaussSimplex<dim0>(degree),
                                                  vertices);
-
-
 
   // actual integration test
   const auto &       JxW     = quad_rule_over_triangle.get_weights();
@@ -217,7 +210,6 @@ TEST(CGAL, AreaTestCodimension0)
     {
       sum += 1.0 * JxW[q];
     }
-
 
   EXPECT_NEAR(sum, correct_result, 1e-12);
 }

--- a/include/cgal/wrappers.h
+++ b/include/cgal/wrappers.h
@@ -1,0 +1,51 @@
+#ifndef dealii_cgal_wrappers_h
+#define dealii_cgal_wrappers_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/point.h>
+
+#ifdef DEAL_II_WITH_CGAL
+
+#  include <boost/config.hpp>
+
+#  include <CGAL/Bbox_2.h>
+#  include <CGAL/Bbox_3.h>
+#  include <CGAL/Cartesian.h>
+#  include <CGAL/IO/io.h>
+#  include <CGAL/Origin.h>
+
+namespace CGALWrappers
+{
+  template <typename CGALPointType, int dim>
+  inline CGALPointType
+  to_cgal(const dealii::Point<dim> &p)
+  {
+    if constexpr (dim == 1)
+      return CGALPointType(p[0]);
+    else if constexpr (dim == 2)
+      return CGALPointType(p[0], p[1]);
+    else if constexpr (dim == 3)
+      return CGALPointType(p[0], p[1], p[2]);
+    else
+      Assert(false, dealii::ExcNotImplemented());
+  }
+
+  template <int dim, typename CGALPointType>
+  inline dealii::Point<dim>
+  to_dealii(const CGALPointType &p)
+  {
+    if constexpr (dim == 1)
+      return dealii::Point<dim>(CGAL::to_double(p.x()));
+    else if constexpr (dim == 2)
+      return dealii::Point<dim>(CGAL::to_double(p.x()), CGAL::to_double(p.y()));
+    else if constexpr (dim == 3)
+      return dealii::Point<dim>(CGAL::to_double(p.x()),
+                                CGAL::to_double(p.y()),
+                                CGAL::to_double(p.z()));
+    else
+      Assert(false, dealii::ExcNotImplemented());
+  }
+} // namespace CGALWrappers
+#endif
+#endif

--- a/source/compute_intersections.cc
+++ b/source/compute_intersections.cc
@@ -24,15 +24,18 @@
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/grid_tools_cache.h>
 
-#include "moonolith_tools.h"
-
-using namespace dealii;
-
 #include <set>
 #include <tuple>
 #include <vector>
 
+#include "cgal/wrappers.h"
+#include "moonolith_tools.h"
+
+using namespace dealii;
+
 #if defined DEAL_II_WITH_CGAL && defined DEAL_II_PREFER_CGAL_OVER_PARMOONOLITH
+
+using namespace CGALWrappers;
 
 #  include <CGAL/Boolean_set_operations_2.h>
 #  include <CGAL/Constrained_Delaunay_triangulation_2.h>
@@ -173,8 +176,6 @@ namespace internal
   }
 } // namespace internal
 
-
-
 namespace dealii
 {
   namespace NonMatching
@@ -208,9 +209,8 @@ namespace dealii
 
           for (unsigned int i = 0; i < 4; ++i)
             {
-              vertices_cell0[i] = CGAL_Point(
-                deformed_vertices_cell0[i][0],
-                deformed_vertices_cell0[i][1]); // get x,y coords of the
+              vertices_cell0[i] = to_cgal<CGAL_Point>(
+                deformed_vertices_cell0[i])); // get x,y coords of the
                                                 // deformed vertices
             }
 
@@ -221,15 +221,13 @@ namespace dealii
 
           for (unsigned int i = 0; i < n_vertices_cell1; ++i)
             {
-              vertices_cell1[i] = CGAL_Point(deformed_vertices_cell1[i][0],
-                                             deformed_vertices_cell1[i][1]);
+              vertices_cell1[i] = to_cgal<CGAL_Point>(deformed_vertices_cell1[i]));
             }
 
-
-
+          // to be consistent with dealii
           std::swap(vertices_cell0[2], vertices_cell0[3]);
-          std::swap(vertices_cell1[2],
-                    vertices_cell1[3]); // to be consistent with dealii
+          std::swap(vertices_cell1[2], vertices_cell1[3]);
+
           const auto inters =
             ::internal::compute_intersection_of_cells<4, 4>(vertices_cell0,
                                                             vertices_cell1);
@@ -243,26 +241,19 @@ namespace dealii
               if (size_poly == 4)
                 {
                   std::array<Point<spacedim>, 4> vertices_array{
-                    {Point<spacedim>(CGAL::to_double(poly.vertex(0).x()),
-                                     CGAL::to_double(poly.vertex(0).y())),
-                     Point<spacedim>(CGAL::to_double(poly.vertex(1).x()),
-                                     CGAL::to_double(poly.vertex(1).y())),
-                     Point<spacedim>(CGAL::to_double(poly.vertex(3).x()),
-                                     CGAL::to_double(poly.vertex(3).y())),
-                     Point<spacedim>(CGAL::to_double(poly.vertex(2).x()),
-                                     CGAL::to_double(poly.vertex(2).y()))}};
+                    {to_dealii<spacedim>(poly.vertex(0)),
+                     to_dealii<spacedim>(poly.vertex(1)),
+                     to_dealii<spacedim>(poly.vertex(3)),
+                     to_dealii<spacedim>(poly.vertex(2))}};
                   return compute_linear_transformation<dim0, spacedim, 4>(
                     QGauss<dim0>(degree), vertices_array); // 4 points
                 }
               else if (size_poly == 3)
                 {
                   std::array<Point<spacedim>, 3> vertices_array{
-                    {Point<spacedim>(CGAL::to_double(poly.vertex(0).x()),
-                                     CGAL::to_double(poly.vertex(0).y())),
-                     Point<spacedim>(CGAL::to_double(poly.vertex(1).x()),
-                                     CGAL::to_double(poly.vertex(1).y())),
-                     Point<spacedim>(CGAL::to_double(poly.vertex(2).x()),
-                                     CGAL::to_double(poly.vertex(2).y()))}};
+                    {to_dealii<spacedim>(poly.vertex(0)),
+                     to_dealii<spacedim>(poly.vertex(1)),
+                     to_dealii<spacedim>(poly.vertex(2))}};
                   return compute_linear_transformation<dim0, spacedim, 3>(
                     QGaussSimplex<dim0>(degree),
                     vertices_array); // 3 points => use Quadrature for simplices
@@ -287,12 +278,9 @@ namespace dealii
                         {
                           for (unsigned int i = 0; i < 3; ++i)
                             {
-                              vertices[i] = Point<spacedim>{
-                                CGAL::to_double(cdt.triangle(f).vertex(i).x()),
-                                CGAL::to_double(cdt.triangle(f).vertex(i).y())};
+                              vertices[i] =
+                                to_dealii<spacedim>(cdt.triangle(f).vertex(i));
                             }
-
-
 
                           const auto &linear_transf =
                             compute_linear_transformation<dim0, spacedim, 3>(
@@ -328,13 +316,10 @@ namespace dealii
 
           for (unsigned int i = 0; i < 4; ++i)
             {
-              vertices_cell0[i] = CGAL_Point(
-                deformed_vertices_cell0[i][0],
-                deformed_vertices_cell0[i][1]); // get x,y coords of the
-                                                // deformed vertices
+              vertices_cell0[i] = to_cal<CGAL_Point>(
+                deformed_vertices_cell0[i]); // get x,y coords of the
+                                             // deformed vertices
             }
-
-
 
           std::array<CGAL_Point, 2> vertices_cell1;
 
@@ -342,8 +327,8 @@ namespace dealii
 
           for (unsigned int i = 0; i < 2; ++i)
             {
-              vertices_cell1[i] = CGAL_Point(deformed_vertices_cell1[i][0],
-                                             deformed_vertices_cell1[i][1]);
+              vertices_cell1[i] =
+                to_cal<CGAL_Point>(deformed_vertices_cell1[i]);
             }
           const auto inters =
             ::internal::compute_intersection_of_cells<4, 2>(vertices_cell0,
@@ -354,10 +339,8 @@ namespace dealii
               if (const auto *s = boost::get<CGAL_Segment>(&*inters))
                 {
                   std::array<Point<spacedim>, 2> vertices_array{
-                    {Point<spacedim>(CGAL::to_double(s->vertex(0).x()),
-                                     CGAL::to_double(s->vertex(0).y())),
-                     Point<spacedim>(CGAL::to_double(s->vertex(1).x()),
-                                     CGAL::to_double(s->vertex(1).y()))}};
+                    {to_dealii<spacedim>(s->vertex(0).y())),
+                     to_dealii<spacedim>(s->vertex(1).y()))}};
 
                   return (s->is_degenerate()) ?
                            Quadrature<spacedim>() :


### PR DESCRIPTION
We can now create a deal.II triangulation from a CGAL triangulation. 

<img width="641" alt="image" src="https://user-images.githubusercontent.com/2919756/164343219-07616dc7-60af-45b9-9a77-7cb1345a7d1f.png">

Not very exciting picture of 60 randomly generated vertices.