### PR TITLE
CGAL 3D conversions.

### DIFF
--- a/dealii_tests/cgal_01.cc
+++ b/dealii_tests/cgal_01.cc
@@ -1,0 +1,84 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2020 by the deal.II authors
+//
+//    This file is subject to LGPL and may not be distributed
+//    without copyright and license information. Please refer
+//    to the file deal.II/doc/license.html for the  text  and
+//    further information on this license.
+//
+//-----------------------------------------------------------
+
+// Build a polyhedron for each deal.II cell, and output it.
+
+#include <deal.II/fe/mapping.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <CGAL/IO/io.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Simple_cartesian.h>
+
+#include <fstream>
+
+typedef CGAL::Simple_cartesian<double> K;
+typedef CGAL::Polyhedron_3<K>          Polyhedron;
+
+
+#include "cgal/wrappers.h"
+#include "tests.h"
+template <int dim, int spacedim>
+void
+test()
+{
+  std::vector<std::vector<unsigned int>> d2t = {{}, {2}, {3, 4}, {4, 5, 6, 8}};
+
+  // unsigned int i = 0;
+  for (const auto nv : d2t[dim])
+    {
+      Triangulation<dim, spacedim> tria;
+      Polyhedron                   poly;
+
+      const auto ref     = ReferenceCell::n_vertices_to_type(dim, nv);
+      const auto mapping = ref.template get_default_mapping<dim, spacedim>(1);
+
+      GridGenerator::reference_cell(tria, ref);
+
+      const auto cell = tria.begin_active();
+      CGALWrappers::to_cgal(cell, *mapping, poly);
+
+      deallog << "dim: " << dim << ", spacedim: " << spacedim << std::endl;
+      if (poly.is_valid())
+        {
+          deallog << "Valid polyhedron" << std::endl;
+        }
+      else
+        {
+          deallog << "Invalid polyhedron" << std::endl;
+        }
+      if (poly.is_closed())
+        {
+          deallog << "Closed polyhedron" << std::endl;
+        }
+      else
+        {
+          deallog << "Open polyhedron" << std::endl;
+        }
+      deallog << poly << std::endl;
+    }
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  initlog();
+  test<1, 1>();
+  test<1, 2>();
+  test<1, 3>();
+  test<2, 2>();
+  test<2, 3>();
+  test<3, 3>();
+}

--- a/dealii_tests/cgal_01.output
+++ b/dealii_tests/cgal_01.output
@@ -1,0 +1,159 @@
+
+DEAL::dim: 1, spacedim: 1
+DEAL::Invalid polyhedron
+DEAL::Open polyhedron
+DEAL::OFF
+2 1 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+3  0 1 0
+
+
+DEAL::dim: 1, spacedim: 2
+DEAL::Invalid polyhedron
+DEAL::Open polyhedron
+DEAL::OFF
+2 1 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+3  0 1 0
+
+
+DEAL::dim: 1, spacedim: 3
+DEAL::Invalid polyhedron
+DEAL::Open polyhedron
+DEAL::OFF
+2 1 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+3  0 1 0
+
+
+DEAL::dim: 2, spacedim: 2
+DEAL::Valid polyhedron
+DEAL::Open polyhedron
+DEAL::OFF
+3 1 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+0.00000 1.00000 0.00000
+3  0 1 2
+
+
+DEAL::dim: 2, spacedim: 2
+DEAL::Valid polyhedron
+DEAL::Open polyhedron
+DEAL::OFF
+4 1 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+0.00000 1.00000 0.00000
+1.00000 1.00000 0.00000
+4  0 1 3 2
+
+
+DEAL::dim: 2, spacedim: 3
+DEAL::Valid polyhedron
+DEAL::Open polyhedron
+DEAL::OFF
+3 1 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+0.00000 1.00000 0.00000
+3  0 1 2
+
+
+DEAL::dim: 2, spacedim: 3
+DEAL::Valid polyhedron
+DEAL::Open polyhedron
+DEAL::OFF
+4 1 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+0.00000 1.00000 0.00000
+1.00000 1.00000 0.00000
+4  0 1 3 2
+
+
+DEAL::dim: 3, spacedim: 3
+DEAL::Valid polyhedron
+DEAL::Closed polyhedron
+DEAL::OFF
+4 4 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+0.00000 1.00000 0.00000
+0.00000 0.00000 1.00000
+3  0 1 2
+3  1 0 3
+3  2 1 3
+3  0 2 3
+
+
+DEAL::dim: 3, spacedim: 3
+DEAL::Valid polyhedron
+DEAL::Closed polyhedron
+DEAL::OFF
+5 5 0
+
+-1.00000 -1.00000 0.00000
+1.00000 -1.00000 0.00000
+-1.00000 1.00000 0.00000
+1.00000 1.00000 0.00000
+0.00000 0.00000 1.00000
+4  0 1 3 2
+3  1 0 4
+3  3 1 4
+3  2 3 4
+3  0 2 4
+
+
+DEAL::dim: 3, spacedim: 3
+DEAL::Valid polyhedron
+DEAL::Closed polyhedron
+DEAL::OFF
+6 5 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+0.00000 1.00000 0.00000
+0.00000 0.00000 1.00000
+1.00000 0.00000 1.00000
+0.00000 1.00000 1.00000
+3  0 1 2
+4  1 0 3 4
+4  1 4 5 2
+4  3 0 2 5
+3  4 3 5
+
+
+DEAL::dim: 3, spacedim: 3
+DEAL::Valid polyhedron
+DEAL::Closed polyhedron
+DEAL::OFF
+8 6 0
+
+0.00000 0.00000 0.00000
+1.00000 0.00000 0.00000
+0.00000 1.00000 0.00000
+1.00000 1.00000 0.00000
+0.00000 0.00000 1.00000
+1.00000 0.00000 1.00000
+0.00000 1.00000 1.00000
+1.00000 1.00000 1.00000
+4  0 1 3 2
+4  1 0 4 5
+4  3 1 5 7
+4  2 3 7 6
+4  4 0 2 6
+4  5 4 6 7
+
+

--- a/gtests/cgal_triangulation.cc
+++ b/gtests/cgal_triangulation.cc
@@ -1,6 +1,12 @@
 #include <deal.II/base/config.h>
 
+#include <deal.II/fe/mapping.h>
+#include <deal.II/fe/mapping_fe.h>
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 
 #include <gtest/gtest.h>
@@ -15,16 +21,48 @@ using namespace dealii;
 // #ifdef DEAL_II_WIHT_CGAL
 
 #include <CGAL/Delaunay_triangulation_2.h>
+#include <CGAL/IO/PLY.h>
+#include <CGAL/IO/io.h>
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#include <CGAL/Mesh_criteria_3.h>
+#include <CGAL/Mesh_triangulation_3.h>
+#include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
+#include <CGAL/Polyhedral_mesh_domain_3.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Polyhedron_incremental_builder_3.h>
 #include <CGAL/Regular_triangulation_2.h>
 #include <CGAL/Simple_cartesian.h>
+#include <CGAL/boost/graph/helpers.h>
+#include <CGAL/make_mesh_3.h>
 #include <CGAL/point_generators_2.h>
+#include <CGAL/refine_mesh_3.h>
 
 #include "cgal/wrappers.h"
 
 // typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
-typedef CGAL::Simple_cartesian<double>    K;
-typedef CGAL::Delaunay_triangulation_2<K> Delaunay;
-typedef Delaunay::Point                   DPoint;
+typedef CGAL::Simple_cartesian<double>                K;
+typedef CGAL::Delaunay_triangulation_2<K>             Delaunay;
+typedef Delaunay::Point                               DPoint;
+typedef CGAL::Polyhedron_3<K>                         Polyhedron;
+typedef Polyhedron::HalfedgeDS                        HalfedgeDS;
+typedef CGAL::Polyhedral_mesh_domain_3<Polyhedron, K> Mesh_domain;
+
+
+#ifdef CGAL_CONCURRENT_MESH_3
+typedef CGAL::Parallel_tag Concurrency_tag;
+#else
+typedef CGAL::Sequential_tag Concurrency_tag;
+#endif
+// Triangulation
+typedef CGAL::
+  Mesh_triangulation_3<Mesh_domain, CGAL::Default, Concurrency_tag>::type Tr;
+typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr>                       C3t3;
+// Criteria
+typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
+// To avoid verbose function and named parameters call
+using namespace CGAL::parameters;
+
 
 TEST(CGAL, Delaunay2D)
 {
@@ -65,5 +103,85 @@ TEST(CGAL, Delaunay2D)
   ASSERT_EQ(tria.n_active_cells(), cgal_tria.number_of_faces());
   ASSERT_EQ(tria.n_vertices(), cgal_tria.number_of_vertices());
 }
+
+
+TYPED_TEST(DimSpacedimTester, CGALConversions)
+{
+  constexpr auto dim      = TestFixture::dim;
+  constexpr auto spacedim = TestFixture::spacedim;
+
+  std::vector<std::vector<unsigned int>> d2t = {{}, {2}, {3, 4}, {4, 5, 6, 8}};
+  // std::vector<std::vector<double>>       measures = {{},
+  //                                              {1},
+  //                                              {0.5, 1.0},
+  //                                              {1. / 6., 4.
+  //                                              / 3., 0.5,
+  //                                              1}};
+
+  // unsigned int i = 0;
+  for (const auto nv : d2t[dim])
+    {
+      Triangulation<dim, spacedim> tria;
+      Polyhedron                   poly;
+
+      const auto ref     = ReferenceCell::n_vertices_to_type(dim, nv);
+      const auto mapping = ref.template get_default_mapping<dim, spacedim>(1);
+
+      GridGenerator::reference_cell(tria, ref);
+
+      const auto cell = tria.begin_active();
+      CGALWrappers::to_cgal(cell, *mapping, poly);
+      ASSERT_TRUE(poly.is_valid() || dim == 1);
+      if (dim == 3)
+        {
+          ASSERT_TRUE(poly.is_closed());
+        }
+    }
+}
+
+// TEST(CGAL, IntersectCubes)
+// {
+//   typedef CGAL::Sequential_tag Concurrency_tag;
+//   // Triangulation
+//   typedef CGAL::
+//     Mesh_triangulation_3<Mesh_domain, CGAL::Default, Concurrency_tag>::type
+//     Tr;
+//   typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
+//   // Criteria
+//   typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
+
+//   Triangulation<3> tria;
+//   GridGenerator::hyper_cube(tria, -1, 1);
+//   const auto &mapping = get_default_linear_mapping(tria);
+
+//   Polyhedron poly;
+//   CGALWrappers::to_cgal(tria.begin_active(), mapping, poly);
+//   CGAL::Polygon_mesh_processing::triangulate_faces(poly);
+
+//   Mesh_domain domain1(poly);
+
+//   // Mesh criteria (no cell_size set)
+//   Mesh_criteria criteria(facet_angle            = 25,
+//                          facet_size             = 0.15,
+//                          facet_distance         = 0.008,
+//                          cell_radius_edge_ratio = 3);
+//   // Mesh generation
+//   C3t3 c3t31 =
+//     CGAL::make_mesh_3<C3t3>(domain1, criteria, no_perturb(), no_exude());
+
+//   GridTools::rotate(numbers::PI_4, 0, tria);
+//   GridTools::rotate(numbers::PI_4, 2, tria);
+//   Polyhedron poly2;
+//   CGALWrappers::to_cgal(tria.begin_active(), mapping, poly2);
+//   CGAL::Polygon_mesh_processing::triangulate_faces(poly2);
+
+//   Mesh_domain domain2(poly2);
+//   C3t3        c3t32 =
+//     CGAL::make_mesh_3<C3t3>(domain2, criteria, no_perturb(), no_exude());
+
+//   const std::array<boost::optional<C3t3 *>, 4> boolean_operations;
+//   CGAL::Polygon_mesh_processing::corefine_and_compute_boolean_operations(
+//     c3t31, c3t32, boolean_operations);
+// }
 
 // #endif

--- a/include/cgal/wrappers.h
+++ b/include/cgal/wrappers.h
@@ -5,6 +5,10 @@
 
 #include <deal.II/base/point.h>
 
+#include <deal.II/fe/mapping.h>
+
+#include <deal.II/grid/tria.h>
+
 #ifdef DEAL_II_WITH_CGAL
 
 #  include <boost/config.hpp>
@@ -12,24 +16,209 @@
 #  include <CGAL/Bbox_2.h>
 #  include <CGAL/Bbox_3.h>
 #  include <CGAL/Cartesian.h>
+#  include <CGAL/Dimension.h>
 #  include <CGAL/IO/io.h>
 #  include <CGAL/Origin.h>
+#  include <CGAL/Polygon_mesh_processing/repair_polygon_soup.h>
+#  include <CGAL/Polyhedron_3.h>
+#  include <CGAL/Polyhedron_incremental_builder_3.h>
+#  include <CGAL/Simple_cartesian.h>
+
 
 namespace CGALWrappers
 {
+  /**
+   * Convert from deal.II Point to any compatible CGAL point.
+   *
+   * @tparam CGALPointType Any of the CGAL point types
+   * @tparam dim Dimension of the point
+   * @param [in] p An input deal.II Point<dim>
+   * @return CGALPointType A CGAL point
+   */
+  template <typename CGALPointType, int dim>
+  inline CGALPointType
+  to_cgal(const dealii::Point<dim> &p);
+
+  /**
+   * Convert from various CGAL point types to deal.II Point.
+   * @tparam dim Dimension of the point
+   * @tparam CGALPointType Any of the CGAL point types
+   * @param p
+   * @return dealii::Point<dim>
+   */
+  template <int dim, typename CGALPointType>
+  inline dealii::Point<dim>
+  to_dealii(const CGALPointType &p);
+
+  /**
+   * Build a CGAL Polyhedron from a deal.II cell.
+   *
+   * If the @p poly argument is not null, the cell is appended to the existing
+   * polyhedrons in @p poly.
+   *
+   * @tparam PolyhedronType A compatible with CGAL polyhedron
+   * @tparam dim Dimension of the cell
+   * @tparam spacedim Dimension of the embedding space
+   * @param poly The output polyhedron
+   * @param cell The input deal.II cell
+   */
+  template <typename PolyhedronType, int dim, int spacedim>
+  void
+  to_cgal(
+    const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell,
+    const dealii::Mapping<dim, spacedim> &                              mapping,
+    PolyhedronType &                                                    poly);
+
+  /**
+   * Given a deal.II Triangulation, return the corresponding CGAL Polyhedron.
+   *
+   * @tparam PolyhedronType
+   * @tparam dim
+   * @tparam spacedim
+   * @param tria
+   * @param mapping
+   * @param poly
+   */
+  template <typename PolyhedronType, int dim, int spacedim>
+  void
+  to_cgal(const typename dealii::Triangulation<dim, spacedim> &tria,
+          const dealii::Mapping<dim, spacedim> &               mapping,
+          PolyhedronType &                                     poly);
+
+  namespace internal
+  {
+    /**
+     * A CGAL modifier, used to create a polyhedron from a deal.II cell.
+     * @tparam HDS A halfedge data structure compatible with CGAL
+     * @tparam dim Dimension of the cell
+     * @tparam spacedim Dimension of the embedding space
+     */
+    template <class HDS, int dim, int spacedim>
+    class BuildCell : public CGAL::Modifier_base<HDS>
+    {
+    public:
+      BuildCell(
+        const typename dealii::Triangulation<dim, spacedim>::cell_iterator
+          &                                   cell,
+        const dealii::Mapping<dim, spacedim> &mapping)
+        : cell(cell)
+        , mapping(mapping)
+      {}
+      void
+      operator()(HDS &hds)
+      {
+        // constexpr unsigned int dim = CellIterator::AccessorType::dimension;
+        // Postcondition: hds is a valid polyhedral surface.
+        CGAL::Polyhedron_incremental_builder_3<HDS> B(hds, true);
+        typedef typename HDS::Vertex                Vertex;
+        typedef typename Vertex::Point              CGALPoint;
+
+        const auto vertices = mapping.get_vertices(cell);
+
+        auto add_vertices = [&]() {
+          for (unsigned int i = 0; i < cell->n_vertices(); ++i)
+            B.add_vertex(CGALWrappers::to_cgal<CGALPoint>(vertices[i]));
+        };
+
+        auto add_facet = [&](const std::vector<unsigned int> &facet) {
+          B.add_facet(facet.begin(), facet.end());
+        };
+
+        switch (cell->n_vertices())
+          {
+            case 2:
+              B.begin_surface(cell->n_vertices(), 1);
+              add_vertices();
+              add_facet({0, 1, 0});
+              B.end_surface();
+              break;
+            case 3:
+              B.begin_surface(cell->n_vertices(), 1);
+              add_vertices();
+              add_facet({0, 1, 2});
+              B.end_surface();
+              break;
+            case 4:
+              if constexpr (dim == 2)
+                {
+                  B.begin_surface(cell->n_vertices(), 1);
+                  add_vertices();
+                  add_facet({0, 1, 3, 2});
+                  B.end_surface();
+                }
+              else
+                {
+                  B.begin_surface(cell->n_vertices(), 4);
+                  add_vertices();
+                  add_facet({0, 1, 2});
+                  add_facet({1, 0, 3});
+                  add_facet({2, 1, 3});
+                  add_facet({0, 2, 3});
+                  B.end_surface();
+                }
+              break;
+            case 5:
+              B.begin_surface(cell->n_vertices(), 5);
+              add_vertices();
+              add_facet({0, 1, 3, 2});
+              add_facet({1, 0, 4});
+              add_facet({3, 1, 4});
+              add_facet({2, 3, 4});
+              add_facet({0, 2, 4});
+              B.end_surface();
+              break;
+            case 6:
+              B.begin_surface(cell->n_vertices(), 5);
+              add_vertices();
+              add_facet({0, 1, 2});
+              add_facet({1, 0, 3, 4});
+              add_facet({1, 4, 5, 2});
+              add_facet({3, 0, 2, 5});
+              add_facet({4, 3, 5});
+              B.end_surface();
+              break;
+            case 8:
+              B.begin_surface(cell->n_vertices(), 6);
+              add_vertices();
+              add_facet({0, 1, 3, 2});
+              add_facet({1, 0, 4, 5});
+              add_facet({3, 1, 5, 7});
+              add_facet({2, 3, 7, 6});
+              add_facet({4, 0, 2, 6});
+              add_facet({5, 4, 6, 7});
+              B.end_surface();
+              break;
+            default:
+              dealii::ExcInternalError();
+          }
+      }
+
+    private:
+      const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell;
+      const dealii::Mapping<dim, spacedim> &mapping;
+    };
+  } // namespace internal
+
+#  ifndef DOXYGEN
+  // Template implementations
   template <typename CGALPointType, int dim>
   inline CGALPointType
   to_cgal(const dealii::Point<dim> &p)
   {
-    if constexpr (dim == 1)
+    constexpr int cdim = CGALPointType::Ambient_dimension::value;
+    static_assert(dim <= cdim, "Only dim <= cdim supported");
+    if constexpr (cdim == 1)
       return CGALPointType(p[0]);
-    else if constexpr (dim == 2)
-      return CGALPointType(p[0], p[1]);
-    else if constexpr (dim == 3)
-      return CGALPointType(p[0], p[1], p[2]);
+    else if constexpr (cdim == 2)
+      return CGALPointType(p[0], dim > 1 ? p[1] : 0);
+    else if constexpr (cdim == 3)
+      return CGALPointType(p[0], dim > 1 ? p[1] : 0, dim > 2 ? p[2] : 0);
     else
       Assert(false, dealii::ExcNotImplemented());
+    return CGALPointType();
   }
+
+
 
   template <int dim, typename CGALPointType>
   inline dealii::Point<dim>
@@ -46,6 +235,22 @@ namespace CGALWrappers
     else
       Assert(false, dealii::ExcNotImplemented());
   }
+
+
+
+  template <typename PolyhedronType, int dim, int spacedim>
+  void
+  to_cgal(
+    const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell,
+    const dealii::Mapping<dim, spacedim> &                              mapping,
+    PolyhedronType &                                                    poly)
+  {
+    internal::BuildCell<typename PolyhedronType::HalfedgeDS, dim, spacedim>
+      cell_builder(cell, mapping);
+    poly.delegate(cell_builder);
+  }
+#  endif
+
 } // namespace CGALWrappers
 #endif
 #endif


### PR DESCRIPTION
@fdrmrc, I tried implementing deal.II cells to cgal polyhedron translations, and deal.II two-dimensional triangulation to 

It seems to work for single cells. Now I'd like to use the intersections, but I'm not able (yet) to construct a valid triangulation from a polyhedron to feed to the `CGAL::Polygon_mesh_processing::corefine_and_compute_boolean_operations`. I'll look into it later on. Do you have an idea on how to do that?