### PR TITLE
Elements bdary intersections

### DIFF
--- a/include/compute_intersections.h
+++ b/include/compute_intersections.h
@@ -92,7 +92,23 @@ namespace dealii
     compute_intersection(const GridTools::Cache<dim0, spacedim> &space_cache,
                          const GridTools::Cache<dim1, spacedim> &immersed_cache,
                          const unsigned int                      degree,
-                         const double                            tol = 0.);
+                         const double                            tol = 1e-15);
+
+    template <int dim0, int dim1, int spacedim>
+    std::pair<
+      std::vector<
+        std::tuple<typename Triangulation<dim0, spacedim>::cell_iterator,
+                   typename Triangulation<dim1, spacedim>::cell_iterator,
+                   Quadrature<spacedim>>>,
+      std::vector<
+        std::tuple<typename Triangulation<dim0, spacedim>::cell_iterator,
+                   typename Triangulation<dim1, spacedim>::face_iterator,
+                   Quadrature<spacedim>>>>
+    compute_intersection_including_boundary(
+      const GridTools::Cache<dim0, spacedim> &space_cache,
+      const GridTools::Cache<dim1, spacedim> &immersed_cache,
+      const unsigned int                      degree,
+      const double                            tol = 1e-15);
 
 
 

--- a/include/parsed_tools/grid_info.h
+++ b/include/parsed_tools/grid_info.h
@@ -126,7 +126,7 @@ namespace dealii
                  const dealii::Patterns::PatternBase &pattern =
                    *Convert<T>::to_pattern())
         {
-          return dealii::internal::make_reference_cell_from_int(
+          return dealii::internal::ReferenceCell::make_reference_cell_from_int(
             Convert<int>::to_value(s, pattern));
         }
       };


### PR DESCRIPTION
@Najwaalshehri This should be what you need: can you try it out?

This PR adds `compute_intersection_including_boundary()`, which returns triples with: cell iterator, (boundary) face iterator, and a Quadrature rule over the cell-face intersection, along with the "old" cell-cell intersections. This is meant to be just a quick solution, I will polish it once its well tested.

